### PR TITLE
Bump extend and void-elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,10 +6,7 @@
 var extend = require('extend');
 var encode = require('ent/encode');
 var CustomEvent = require('custom-event');
-var voidElements = require('void-elements').reduce(function (obj, name) {
-  obj[name] = true;
-  return obj;
-}, {});
+var voidElements = require('void-elements');
 
 /**
  * Module exports.

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
   "dependencies": {
     "custom-event": "~1.0.0",
     "ent": "~2.2.0",
-    "extend": "~2.0.0",
-    "void-elements": "~1.0.0"
+    "extend": "^3.0.0",
+    "void-elements": "^2.0.0"
   },
   "devDependencies": {
     "zuul": "1"


### PR DESCRIPTION
npm v3 tries to dedupe the dependencies by default, and keeping dependencies up-to-date helps better deduplication.
- [extend](https://github.com/justmoon/node-extend) from v2.x to v3.x
  - Use global "strict" directive https://github.com/justmoon/node-extend/pull/32
- [void-elements](https://github.com/jadejs/void-elements) from v1.x to v2.x
  - Make the module an object instead of array https://github.com/jadejs/void-elements/issues/5
